### PR TITLE
Implement volume-based portals

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="openjdk-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/Client/src/main/java/me/snover/command/CommandTransfer.java
+++ b/Client/src/main/java/me/snover/command/CommandTransfer.java
@@ -26,7 +26,10 @@ public class CommandTransfer extends Command {
 
     //Commonly used messages
     final Component USAGE = Component.text("Usage:\n/transfer register\n/transfer edit-mode\n/transfer listservers\n/transfer remserver\n/transfer showcoord\n/transfer remcoord\n/transfer test\n/transfer setspawn\n/transfer toggleforcedspawn", NamedTextColor.RED);
-    final Component REGISTER_USAGE = Component.text("Usage: /transfer register <server> <x> <y> <z> (Coordinates optional when used in-game. Server name is case sensitive!)", NamedTextColor.RED);
+    final Component REGISTER_USAGE = Component.text("Usage: /transfer register <server> (When executed in-game, takes the current location of the player. Server name is case sensitive!)\n" +
+            "/transfer register <server> p1|p2|commit (When executed in-game, defines a bounding box p1:p2 that will trigger the transfer. After defining both points, use commit. Server name is case sensitive!)\n" +
+            "/transfer register <server> x y z (trigger is player entering the specified location)\n" +
+            "/transfer register <server> x y z x2 y2 z2 (trigger is player entering the area defined by the bounding box)", NamedTextColor.RED);
     final Component REMSERVER_USAGE = Component.text("Usage: /transfer remserver <server>", NamedTextColor.RED);
     final Component SHOWCOORD_USAGE = Component.text("Usage: /transfer showcoord <server>", NamedTextColor.RED);
     final Component REMCOORD_USAGE = Component.text("Usage: /transfer remcoord <server> <dimension> <x> <y> <z>", NamedTextColor.RED);
@@ -110,6 +113,58 @@ public class CommandTransfer extends Command {
             }
         }
 
+        if (args.length == 3) {
+            if(sender instanceof Player player) {
+                if (!player.isOp() && !player.hasPermission("transferclient.transfer.register")) {
+                    player.sendMessage(DISALLOW);
+                    return false;
+                }
+
+                switch(args[2]){
+                    case "p1":
+                        Events.playerEnterBoundingBoxP1(player, player.getLocation());
+                        return true;
+                    case "p2":
+                        Events.playerEnterBoundingBoxP2(player, player.getLocation());
+                        return true;
+                    case "commit":
+                        var location = Events.getBoundingBoxDefinitionForPlayer(player);
+                        if (location == null) {
+                            sender.sendMessage(Component.text("No bounding box has been defined\n" + REGISTER_USAGE));
+                            return false;
+                        }
+
+                        if(location[0] == null)
+                            location[0] = location[1];
+                        if(location[1] == null)
+                            location[1] = location[0];
+
+                        CoordinateContainer container;
+                        if(CoordinateServerRegistry.exists(tgtServer)) {
+                            container = CoordinateServerRegistry.getContainer(tgtServer);
+                        } else container = new CoordinateContainer(tgtServer);
+
+                        // Normalize coordinates to simplify checking player's position
+                        container.addCoordinateSet(0,
+                                Math.min(location[0].getBlockX(), location[1].getBlockX()),
+                                Math.min(location[0].getBlockY(), location[1].getBlockY()),
+                                Math.min(location[0].getBlockZ(), location[1].getBlockZ()),
+                                Math.max(location[0].getBlockX(), location[1].getBlockX()),
+                                Math.max(location[0].getBlockY(), location[1].getBlockY()),
+                                Math.max(location[0].getBlockZ(), location[1].getBlockZ()));
+                        CoordinateServerRegistry.add(tgtServer, container);
+                        config.saveResources(false, true);
+                        Events.deletePlayerBoundingBoxState(player);
+
+                        return true;
+
+                    default:
+                        sender.sendMessage(REGISTER_USAGE);
+                        return false;
+                }
+            }
+        }
+
         //Begin registration process with given coordinates
         if (args.length == 5) {
             int x;
@@ -130,7 +185,39 @@ public class CommandTransfer extends Command {
                 container = CoordinateServerRegistry.getContainer(tgtServer);
             } else container = new CoordinateContainer(tgtServer);
 
-            container.addCoordinateSet(0, x, y, z);
+            container.addCoordinateSet(0, x, y, z, x, y, z);
+            CoordinateServerRegistry.add(tgtServer, container);
+            config.saveResources(false, true);
+            return true;
+        }
+
+        //Begin registration process with given coordinates for a bounding box
+        if (args.length == 8) {
+            int x, x2;
+            int y, y2;
+            int z, z2;
+
+            try {
+                x = Integer.parseInt(args[2]);
+                y = Integer.parseInt(args[3]);
+                z = Integer.parseInt(args[4]);
+                x2 = Integer.parseInt(args[5]);
+                y2 = Integer.parseInt(args[6]);
+                z2 = Integer.parseInt(args[7]);
+            } catch(NumberFormatException e) {
+                sender.sendMessage(Component.text("Coordinates must contain only whole numbers!\n" + REGISTER_USAGE, NamedTextColor.RED));
+                return false;
+            }
+
+            CoordinateContainer container;
+            if(CoordinateServerRegistry.exists(tgtServer)) {
+                container = CoordinateServerRegistry.getContainer(tgtServer);
+            } else container = new CoordinateContainer(tgtServer);
+
+            // Normalize coordinates to simplify checking player's position
+            container.addCoordinateSet(0,
+                    Math.min(x, x2), Math.min(y, y2), Math.min(z, z2),
+                    Math.max(x, x2), Math.max(y, y2), Math.max(z, z2));
             CoordinateServerRegistry.add(tgtServer, container);
             config.saveResources(false, true);
             return true;
@@ -245,6 +332,11 @@ public class CommandTransfer extends Command {
      * @return Returns {@code true} if command successful
      */
     private boolean executeRemCoord(CommandSender sender, String[] args) {
+        int x, x2;
+        int y, y2;
+        int z, z2;
+
+
         if(sender instanceof Player player) {
             if (!player.isOp() && !player.hasPermission("transferclient.transfer.remcoord")) {
                 player.sendMessage(DISALLOW);
@@ -275,7 +367,7 @@ public class CommandTransfer extends Command {
         if(args[2].contains("nether") || args[2].equals("-1")) id = -1;
         else if (args[2].contains("end") || args[2].equals("1")) id = 1;
         else id = 0;
-        CoordinateServerRegistry.getContainer(args[1]).removeCoordinateSet(id, Integer.parseInt(args[3]), Integer.parseInt(args[4]), Integer.parseInt(args[5]));
+        CoordinateServerRegistry.getContainer(args[1]).removeCoordinateSet(id, x, y, z, x2, y2, z2);
         config.saveResources(false, true);
         sender.sendMessage(Component.text("Removed coordinate set for server: " + args[1], NamedTextColor.AQUA));
         return true;

--- a/Client/src/main/java/me/snover/command/CommandTransfer.java
+++ b/Client/src/main/java/me/snover/command/CommandTransfer.java
@@ -145,14 +145,21 @@ public class CommandTransfer extends Command {
                             container = CoordinateServerRegistry.getContainer(tgtServer);
                         } else container = new CoordinateContainer(tgtServer);
 
+                        int blockXa = location[0].getBlockX();
+                        int blockXb = location[1].getBlockX();
+                        int blockYa = location[0].getBlockY();
+                        int blockYb = location[1].getBlockY();
+                        int blockZa = location[0].getBlockZ();
+                        int blockZb = location[1].getBlockZ();
+
                         // Normalize coordinates to simplify checking player's position
                         container.addCoordinateSet(0,
-                                Math.min(location[0].getBlockX(), location[1].getBlockX()),
-                                Math.min(location[0].getBlockY(), location[1].getBlockY()),
-                                Math.min(location[0].getBlockZ(), location[1].getBlockZ()),
-                                Math.max(location[0].getBlockX(), location[1].getBlockX()),
-                                Math.max(location[0].getBlockY(), location[1].getBlockY()),
-                                Math.max(location[0].getBlockZ(), location[1].getBlockZ()));
+                                Math.min(blockXa, blockXb),
+                                Math.min(blockYa, blockYb),
+                                Math.min(blockZa, blockZb),
+                                Math.max(blockXa, blockXb),
+                                Math.max(blockYa, blockYb),
+                                Math.max(blockZa, blockZb));
                         CoordinateServerRegistry.add(tgtServer, container);
                         config.saveResources(false, true);
                         Events.deletePlayerBoundingBoxState(player);

--- a/Client/src/main/java/me/snover/command/CommandTransfer.java
+++ b/Client/src/main/java/me/snover/command/CommandTransfer.java
@@ -103,7 +103,7 @@ public class CommandTransfer extends Command {
                 int y = player.getLocation().getBlockY();
                 int z = player.getLocation().getBlockZ();
                 sender.sendMessage(Component.text("Registering a new coordinate set:" + "\nx: " + x + "\ny: " + y + "\nz: " + z, NamedTextColor.AQUA));
-                container.addCoordinateSet(id, x, y, z);
+                container.addCoordinateSet(id, x, y, z, x, y, z);
                 CoordinateServerRegistry.add(tgtServer, container);
                 config.saveResources(false, true);
                 return true;
@@ -255,6 +255,22 @@ public class CommandTransfer extends Command {
             sender.sendMessage(REMCOORD_USAGE);
             return false;
         }
+
+        x = Integer.parseInt(args[3]);
+        y = Integer.parseInt(args[4]);
+        z = Integer.parseInt(args[5]);
+        if(args.length != 9)
+        {
+            x2 = x;
+            y2 = y;
+            z2 = z;
+        }
+        else {
+            x2 = Integer.parseInt(args[6]);
+            y2 = Integer.parseInt(args[7]);
+            z2 = Integer.parseInt(args[8]);
+        }
+
         int id;
         if(args[2].contains("nether") || args[2].equals("-1")) id = -1;
         else if (args[2].contains("end") || args[2].equals("1")) id = 1;

--- a/Client/src/main/java/me/snover/command/CommandTransfer.java
+++ b/Client/src/main/java/me/snover/command/CommandTransfer.java
@@ -359,16 +359,16 @@ public class CommandTransfer extends Command {
         x = Integer.parseInt(args[3]);
         y = Integer.parseInt(args[4]);
         z = Integer.parseInt(args[5]);
-        if(args.length != 9)
+        if(args.length == 9)
         {
-            x2 = x;
-            y2 = y;
-            z2 = z;
-        }
-        else {
             x2 = Integer.parseInt(args[6]);
             y2 = Integer.parseInt(args[7]);
             z2 = Integer.parseInt(args[8]);
+        }
+        else {
+            x2 = x;
+            y2 = y;
+            z2 = z;
         }
 
         int id;

--- a/Client/src/main/java/me/snover/command/CommandTransfer.java
+++ b/Client/src/main/java/me/snover/command/CommandTransfer.java
@@ -26,10 +26,11 @@ public class CommandTransfer extends Command {
 
     //Commonly used messages
     final Component USAGE = Component.text("Usage:\n/transfer register\n/transfer edit-mode\n/transfer listservers\n/transfer remserver\n/transfer showcoord\n/transfer remcoord\n/transfer test\n/transfer setspawn\n/transfer toggleforcedspawn", NamedTextColor.RED);
-    final Component REGISTER_USAGE = Component.text("Usage: /transfer register <server> (When executed in-game, takes the current location of the player. Server name is case sensitive!)\n" +
-            "/transfer register <server> p1|p2|commit (When executed in-game, defines a bounding box p1:p2 that will trigger the transfer. After defining both points, use commit. Server name is case sensitive!)\n" +
-            "/transfer register <server> x y z (trigger is player entering the specified location)\n" +
-            "/transfer register <server> x y z x2 y2 z2 (trigger is player entering the area defined by the bounding box)", NamedTextColor.RED);
+    final Component REGISTER_USAGE = Component.text("""
+            Usage: /transfer register <server> (When executed in-game, takes the current location of the player. Server name is case sensitive!)
+            /transfer register <server> p1|p2|commit (When executed in-game, defines a bounding box p1:p2 that will trigger the transfer. After defining both points, use commit. Server name is case sensitive!)
+            /transfer register <server> x y z (trigger is player entering the specified location)
+            /transfer register <server> x y z x2 y2 z2 (trigger is player entering the area defined by the bounding box)""", NamedTextColor.RED);
     final Component REMSERVER_USAGE = Component.text("Usage: /transfer remserver <server>", NamedTextColor.RED);
     final Component SHOWCOORD_USAGE = Component.text("Usage: /transfer showcoord <server>", NamedTextColor.RED);
     final Component REMCOORD_USAGE = Component.text("Usage: /transfer remcoord <server> <dimension> <x> <y> <z>", NamedTextColor.RED);
@@ -392,7 +393,11 @@ public class CommandTransfer extends Command {
         }
         String server = args[1];
         Player tgtPlayer = TransferClient.getPlugin().getServer().getPlayerExact(args[2]);
-        //May need to investigate warning of possible NullPointerException return.
+
+        if(tgtPlayer == null) {
+            sender.sendMessage(Component.text("Could not obtain player instance!", NamedTextColor.DARK_RED));
+            return false;
+        }
         if(!tgtPlayer.isOnline()) {
             sender.sendMessage(Component.text("Player is not online!", NamedTextColor.DARK_RED));
             return false;

--- a/Client/src/main/java/me/snover/command/CommandTransfer.java
+++ b/Client/src/main/java/me/snover/command/CommandTransfer.java
@@ -27,8 +27,8 @@ public class CommandTransfer extends Command {
     //Commonly used messages
     final Component USAGE = Component.text("Usage:\n/transfer register\n/transfer edit-mode\n/transfer listservers\n/transfer remserver\n/transfer showcoord\n/transfer remcoord\n/transfer test\n/transfer setspawn\n/transfer toggleforcedspawn", NamedTextColor.RED);
     final Component REGISTER_USAGE = Component.text("""
-            Usage: /transfer register <server> (When executed in-game, takes the current location of the player. Server name is case sensitive!)
-            /transfer register <server> p1|p2|commit (When executed in-game, defines a bounding box p1:p2 that will trigger the transfer. After defining both points, use commit. Server name is case sensitive!)
+            Usage: /transfer register <server> (When executed in-game, takes the current location of the player)
+            /transfer register <server> p1|p2|commit (When executed in-game, defines a bounding box p1:p2 that will trigger the transfer. After defining both points, use commit)
             /transfer register <server> x y z (trigger is player entering the specified location)
             /transfer register <server> x y z x2 y2 z2 (trigger is player entering the area defined by the bounding box)""", NamedTextColor.RED);
     final Component REMSERVER_USAGE = Component.text("Usage: /transfer remserver <server>", NamedTextColor.RED);
@@ -36,7 +36,7 @@ public class CommandTransfer extends Command {
     final Component REMCOORD_USAGE = Component.text("Usage: /transfer remcoord <server> <dimension> <x> <y> <z>", NamedTextColor.RED);
     final Component TEST_USAGE = Component.text("Usage: /transfer test <server> <player>", NamedTextColor.RED);
     final Component SET_SPAWN_USAGE = Component.text("Usage: /transfer setspawn <x> <y> <z> (coordinates optional when used in-game)", NamedTextColor.RED);
-    final Component SERVER_NOT_FOUND = Component.text("Server not found in registry!", NamedTextColor.RED);
+    final Component SERVER_NOT_FOUND = Component.text("Server not found in registry! Server name is case-sensitive!", NamedTextColor.RED);
     final Component DISALLOW = Component.text("Not Allowed!", NamedTextColor.RED);
 
     @SuppressWarnings({"FieldMayBeFinal", "CanBeFinal"})

--- a/Client/src/main/java/me/snover/event/Events.java
+++ b/Client/src/main/java/me/snover/event/Events.java
@@ -6,6 +6,7 @@ import me.snover.messaging.PluginMessageSender;
 import me.snover.pointer.CoordinateContainer;
 import me.snover.pointer.CoordinateServerRegistry;
 import me.snover.pointer.CoordinateSet;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -23,6 +24,7 @@ public class Events implements Listener {
 
     private static final List<Player> playerLock = new ArrayList<>();
     private static final List<Player> editingPlayer = new ArrayList<>();
+    private static final HashMap<Player, Location[]> playerBoundingBoxState = new HashMap<>();
     Timer lockTimeoutTimer = new Timer();
 
     /**
@@ -115,5 +117,28 @@ public class Events implements Listener {
 
     public static boolean isPlayerEditing(Player player) {
         return editingPlayer.contains(player);
+    }
+
+    public static void playerEnterBoundingBoxP1(Player player, Location l) {
+        if(!playerBoundingBoxState.containsKey(player))
+            playerBoundingBoxState.put(player, new Location[2]);
+        playerBoundingBoxState.get(player)[0] = l;
+    }
+
+    public static void playerEnterBoundingBoxP2(Player player, Location l) {
+        if(!playerBoundingBoxState.containsKey(player))
+            playerBoundingBoxState.put(player, new Location[2]);
+        playerBoundingBoxState.get(player)[1] = l;
+    }
+
+    public static Location[] getBoundingBoxDefinitionForPlayer(Player player) {
+        if(playerBoundingBoxState.containsKey(player))
+            return playerBoundingBoxState.get(player);
+
+        return null;
+    }
+
+    public static void deletePlayerBoundingBoxState(Player player) {
+        playerBoundingBoxState.remove(player);
     }
 }

--- a/Client/src/main/java/me/snover/event/Events.java
+++ b/Client/src/main/java/me/snover/event/Events.java
@@ -54,7 +54,9 @@ public class Events implements Listener {
             CoordinateSet[] set = container.getCoordinateSets();
             for (CoordinateSet coordinateSet : set) {
 
-                if (playerDimId == coordinateSet.getID() && playerX == coordinateSet.getX() && playerY == coordinateSet.getY() && playerZ == coordinateSet.getZ()) {
+                if (playerDimId == coordinateSet.getID() && (playerX >= coordinateSet.getX() && playerX <= coordinateSet.getX2())
+                        && (playerY >= coordinateSet.getY() && playerY <= coordinateSet.getY2())
+                        && (playerZ >= coordinateSet.getZ() && playerZ <= coordinateSet.getZ2()) ) {
                     playerLock.add(player);
                     lockTimeoutTimer.schedule(new TimerTask() {
                         @Override

--- a/Client/src/main/java/me/snover/pointer/CoordinateContainer.java
+++ b/Client/src/main/java/me/snover/pointer/CoordinateContainer.java
@@ -100,13 +100,17 @@ public class CoordinateContainer implements ConfigurationSerializable {
      */
     @SuppressWarnings("JavadocDeclaration")
     private CoordinateSet getCoordinateSet(int id, int x, int y, int z, int x2, int y2, int z2) {
+        // Consider a better matching algorithm?
         for (CoordinateSet coordinateSet : COORDINATE_SET_LIST) {
             int idFromSet = coordinateSet.getID();
             int xFromSet = coordinateSet.getX();
             int yFromSet = coordinateSet.getY();
             int zFromSet = coordinateSet.getZ();
-
-            if (idFromSet == id && xFromSet == x && yFromSet == y && zFromSet == z) return coordinateSet;
+            int x2FromSet = coordinateSet.getX2();
+            int y2FromSet = coordinateSet.getY2();
+            int z2FromSet = coordinateSet.getZ2();
+            if (idFromSet == id && xFromSet == x && yFromSet == y && zFromSet == z
+            && x2FromSet == x2 && y2FromSet == y2 && z2FromSet == z2) return coordinateSet;
         }
 
         return null;

--- a/Client/src/main/java/me/snover/pointer/CoordinateContainer.java
+++ b/Client/src/main/java/me/snover/pointer/CoordinateContainer.java
@@ -26,40 +26,39 @@ public class CoordinateContainer implements ConfigurationSerializable {
 
     /**
      * Adds a set of coordinates to the container as whole numbers
+     * @param id
      * @param x
      * @param y
      * @param z
+     * @param x2
+     * @param y2
+     * @param z2
      */
     @SuppressWarnings("JavadocDeclaration")
-    public void addCoordinateSet(int id, int x, int y, int z) {
+    public void addCoordinateSet(int id, int x, int y, int z, int x2, int y2, int z2) {
 
-        if(coordinateSetExists(id, x, y ,z)) return;
-        CoordinateSet set = new CoordinateSet(id, x, y, z);
+        if(coordinateSetExists(id, x, y, z, x2, y2, z2)) return;
+        CoordinateSet set = new CoordinateSet(id, x, y, z, x2, y2, z2);
         COORDINATE_SET_LIST.add(set);
     }
 
     /**
      * Removes a coordinate set from the container
+     * @param id
      * @param x
      * @param y
      * @param z
+     * @param x2
+     * @param y2
+     * @param z2
      */
     @SuppressWarnings("JavadocDeclaration")
-    public void removeCoordinateSet(int id, int x, int y, int z) {
+    public void removeCoordinateSet(int id, int x, int y, int z, int x2, int y2, int z2) {
+        CoordinateSet coordinateSet = getCoordinateSet(id, x, y, z, x2, y2, z2) ;
 
-        if(!coordinateSetExists(id, x, y, z)) return;
-        for(int i = 0; i < COORDINATE_SET_LIST.size(); i++) {
-            CoordinateSet coordinateSet = COORDINATE_SET_LIST.get(i);
-            int idFromSet = coordinateSet.getID();
-            int xFromSet = coordinateSet.getX();
-            int yFromSet = coordinateSet.getY();
-            int zFromSet = coordinateSet.getZ();
-
-            if(idFromSet == id && xFromSet == x && yFromSet == y && zFromSet == z) {
-                COORDINATE_SET_LIST.remove(i);
-                return;
-            }
-        }
+        if(coordinateSet == null)
+            return;
+        COORDINATE_SET_LIST.remove(coordinateSet);
     }
 
     /**
@@ -74,22 +73,43 @@ public class CoordinateContainer implements ConfigurationSerializable {
 
     /**
      * Check to see if a set of coordinates exist within this container
+     * @param id
      * @param x
      * @param y
      * @param z
+     * @param x2
+     * @param y2
+     * @param z2
      * @return Returns {@code true} if the coordinate set exists.
      */
     @SuppressWarnings("JavadocDeclaration")
-    public boolean coordinateSetExists(int id, int x, int y, int z) {
+    public boolean coordinateSetExists(int id, int x, int y, int z, int x2, int y2, int z2) {
+        return getCoordinateSet(id, x, y, z, x2, y2, z2) != null;
+    }
+
+    /**
+     * Obtain the CoordinateSet object represented by the specified values
+     * @param id
+     * @param x
+     * @param y
+     * @param z
+     * @param x2
+     * @param y2
+     * @param z2
+     * @return Returns null if a match was not found
+     */
+    @SuppressWarnings("JavadocDeclaration")
+    private CoordinateSet getCoordinateSet(int id, int x, int y, int z, int x2, int y2, int z2) {
         for (CoordinateSet coordinateSet : COORDINATE_SET_LIST) {
             int idFromSet = coordinateSet.getID();
             int xFromSet = coordinateSet.getX();
             int yFromSet = coordinateSet.getY();
             int zFromSet = coordinateSet.getZ();
 
-            if (idFromSet == id && xFromSet == x && yFromSet == y && zFromSet == z) return true;
+            if (idFromSet == id && xFromSet == x && yFromSet == y && zFromSet == z) return coordinateSet;
         }
-        return false;
+
+        return null;
     }
 
     /**
@@ -104,11 +124,29 @@ public class CoordinateContainer implements ConfigurationSerializable {
     @Utility
     public @NotNull Map<String, Object> serialize() {
         Map<String, Object> data = new HashMap<>();
+        StringBuilder sb = new StringBuilder();
         data.put("server", SERVER_NAME);
         data.put("size", COORDINATE_SET_LIST.size());
         for(int i = 0; i < COORDINATE_SET_LIST.size(); i++) {
             CoordinateSet set = COORDINATE_SET_LIST.get(i);
-            data.put("set" + i, set.getID() + "_" + set.getX() + "_" + set.getY() + "_" + set.getZ());
+
+            sb.setLength(0);
+            sb.append(set.getID());
+            sb.append('_');
+            sb.append(set.getX());
+            sb.append(':');
+            sb.append(set.getX2());
+            sb.append('_');
+            sb.append(set.getY());
+            sb.append(':');
+            sb.append(set.getY2());
+            sb.append('_');
+            sb.append(set.getZ());
+            sb.append(':');
+            sb.append(set.getZ2());
+            sb.append('_');
+
+            data.put("set" + i, sb.toString());
         }
         return data;
     }
@@ -120,13 +158,29 @@ public class CoordinateContainer implements ConfigurationSerializable {
         for(int i = 0; i < size; i++) {
             String coords = (String) data.get("set" + i);
             String[] split = coords.split("_");
+
             int id;
+            int [] startingCorner = new int[3];
+            int [] endCorner = new int[3];
+            String[] coordRange;
+
 
             //reverse compatibility
             if(split.length < 4) id = 0;
             else id = Integer.parseInt(split[0]);
 
-            container.addCoordinateSet(id, Integer.parseInt(split[1]), Integer.parseInt(split[2]), Integer.parseInt(split[3]));
+            for (int j = 1; j < split.length; ++j) {
+                coordRange = split[j - 1].split(":");
+                startingCorner[j - 1] = Integer.parseInt(coordRange[0]);
+                if(coordRange.length == 1)
+                    endCorner[j - 1] = startingCorner[j - 1];
+                else
+                    endCorner[j - 1] = Integer.parseInt(coordRange[1]);
+            }
+
+            container.addCoordinateSet(id,
+                    startingCorner[0], startingCorner[1], startingCorner[2],
+                    endCorner[0], endCorner[1], endCorner[2]);
         }
         return container;
     }

--- a/Client/src/main/java/me/snover/pointer/CoordinateSet.java
+++ b/Client/src/main/java/me/snover/pointer/CoordinateSet.java
@@ -8,11 +8,19 @@ public class CoordinateSet {
     private final int X;
     private final int Y;
     private final int Z;
-    public CoordinateSet(final int ID, final int X, int Y, final int Z) {
+    private final int X2;
+    private final int Y2;
+    private final int Z2;
+
+
+    public CoordinateSet(final int ID, final int X, int Y, final int Z, int X2, int Y2, int Z2) {
         this.ID = ID;
         this.X = X;
         this.Y = Y;
         this.Z = Z;
+        this.X2 = X2;
+        this.Y2 = Y2;
+        this.Z2 = Z2;
     }
 
     public int getID() {
@@ -25,6 +33,18 @@ public class CoordinateSet {
 
     public int getY() {
         return Y;
+    }
+
+    public int getX2() {
+        return X2;
+    }
+
+    public int getY2() {
+        return Y2;
+    }
+
+    public int getZ2() {
+        return Z2;
     }
 
     public int getZ() {

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Plugin features:
 - Allows for a secret key to help prevent outside interference. This is not necessary if you are using Velocity's MODERN forwarding setting.
 - The `TransferService.jar` file will go in the plugin folder for your Velocity Proxy server while the `TransferClient.jar` file will go in the plugin folder of the Paper Minecraft server. A full list of commands is available by typing in `/transfer`.
 
-After setting up your servers and configuring your proxy in your `velocity.toml` file, you will then be able set up your "portals." The way portals work is that when a player walks onto a given location, it will automatically forward said player to the server that the portal is assigned to.
+After setting up your servers and configuring your proxy in your `velocity.toml` file, you will then be able set up your "portals." The way portals work is that when a player walks onto a given location or space, it will automatically forward said player to the server that the portal is assigned to.
 
 To register a set of coordinates to forward a player when they walk onto them, if you are logged into the server, you must first go into edit-mode using `/transfer edit-mode` to prevent you from teleporting while registering where new coordinate sets.
 
 ![Screenshot of transfer edit](https://i.imgur.com/UdDeaaa.png)
 
-Then you can use the `/transfer register` command to register the coordinates that you are currently standing on. You MUST use the name of the server that you used in the `velocity.toml` file. You also have the option of typing in the coordinates yourself. You may add the coordinates manually through the console if you wish.
+Then you can use the `/transfer register` command to register the coordinates of the point you are currently standing on or `/transfer register p1/p2/commit` to register a volume defined by locations `p1` and `p2` (the volume is registered with the `commit` argument). You MUST use the name of the server that you used in the `velocity.toml` file. You also have the option of typing in the coordinates yourself. You may add the coordinates manually through the console if you wish.
 ![Screenshot of transfer registration](https://i.imgur.com/OHEvqWm.png)
 
 And lastly, if you want players to spawn at the same spawn point every time they join the server, you can set that point by using two commands. `/transfer setspawn` to set the spawn point of where you are currently standing, and `/transfer toggleforcedspawn` to force players to spawn in the same spot every time.

--- a/Service/src/main/java/me/snover/config/CompositeConfiguration.java
+++ b/Service/src/main/java/me/snover/config/CompositeConfiguration.java
@@ -5,6 +5,7 @@ import me.snover.TransferService;
 
 import java.io.*;
 import java.net.JarURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,7 +45,7 @@ public class CompositeConfiguration {
                 if (!pluginDir.exists()) Files.createDirectories(Paths.get(pluginDir.getPath()));
 
                 //Begin TOML extraction
-                URL url = new URL("jar:file:" + WORKING_DIRECTORY + "/plugins/TransferService.jar!/secret.toml");
+                URL url = URI.create("jar:file:" + WORKING_DIRECTORY + "/plugins/TransferService.jar!/secret.toml").toURL();
                 JarURLConnection connection = (JarURLConnection) url.openConnection();
                 JarFile jarFile = connection.getJarFile();
                 JarEntry jarEntry = connection.getJarEntry();


### PR DESCRIPTION
Modified the current implementation to register the portals as volumes instead of just single block locations.
Added fields to the CoordinateSet object, reimplemented the existing logic on top of these, meaning you can still opt to create portals on a single block (volumes bound by the same block), and added a new command for configuring the volume both interactively and through a single command, just like you're currently able to.